### PR TITLE
chore: change namespace from Jaytaph to MinVWS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "license": "BSD-3-Clause",
     "autoload": {
         "psr-4": {
-            "Jaytaph\\TypeArray\\": "src/"
+            "MinVWS\\TypeArray\\": "src/"
         }
     },
     "authors": [

--- a/src/Doctrine/DBAL/Types/TypeArrayType.php
+++ b/src/Doctrine/DBAL/Types/TypeArrayType.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Jaytaph\TypeArray\Doctrine\DBAL\Types;
+namespace MinVWS\TypeArray\Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Deprecations\Deprecation;
 use JsonException;
-use Jaytaph\TypeArray\TypeArray;
+use MinVWS\TypeArray\TypeArray;
 
 use function is_resource;
 use function json_encode;

--- a/src/Exception/IncorrectDataTypeException.php
+++ b/src/Exception/IncorrectDataTypeException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Jaytaph\TypeArray\Exception;
+namespace MinVWS\TypeArray\Exception;
 
 class IncorrectDataTypeException extends \Exception
 {

--- a/src/Exception/InvalidIndexException.php
+++ b/src/Exception/InvalidIndexException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Jaytaph\TypeArray\Exception;
+namespace MinVWS\TypeArray\Exception;
 
 class InvalidIndexException extends \Exception
 {

--- a/src/TypeArray.php
+++ b/src/TypeArray.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Jaytaph\TypeArray;
+namespace MinVWS\TypeArray;
 
-use Jaytaph\TypeArray\Exception\IncorrectDataTypeException;
-use Jaytaph\TypeArray\Exception\InvalidIndexException;
+use MinVWS\TypeArray\Exception\IncorrectDataTypeException;
+use MinVWS\TypeArray\Exception\InvalidIndexException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 

--- a/tests/TypeArrayTest.php
+++ b/tests/TypeArrayTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Tests;
 
-use Jaytaph\TypeArray\Exception\IncorrectDataTypeException;
-use Jaytaph\TypeArray\Exception\InvalidIndexException;
-use Jaytaph\TypeArray\TypeArray;
+use MinVWS\TypeArray\Exception\IncorrectDataTypeException;
+use MinVWS\TypeArray\Exception\InvalidIndexException;
+use MinVWS\TypeArray\TypeArray;
 use PHPUnit\Framework\TestCase;
 
 class TypeArrayTest extends TestCase


### PR DESCRIPTION
> [!NOTE]
> This PR depends on #3 

Change the package's namespace from `Jaytaph\TypeArray` to `MinVWS\TypeArray`.
